### PR TITLE
Fix flaky image build

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -235,8 +235,6 @@ namespace :docker do
     end
     version_suffix = ENV["image_version_suffix"]
     tag_suffix = ENV["tag_suffix"]
-    tag = ENV["tag"] || ""
-    target = ENV.fetch("target", "ruby")
     ruby_version, tags = make_tags(ruby_version, version_suffix, tag_suffix)
 
     tags.each do |tag|
@@ -259,7 +257,6 @@ namespace :docker do
   namespace :manifest do
     task :create do
       ruby_version = ENV.fetch("ruby_version")
-      ubuntu_version = ENV.fetch("ubuntu_version")
       architectures = ENV.fetch("architectures").split(' ')
       manifest_suffix = ENV.fetch("manifest_suffix", nil)
       image_version_suffix = ENV["image_version_suffix"]

--- a/Rakefile
+++ b/Rakefile
@@ -130,8 +130,7 @@ namespace :docker do
   end
 
   def get_ruby_master_head_hash
-    # Use the same hash throughout the same CircleCI job
-    if ENV.key?('CIRCLE_BUILD_NUM') && File.exist?(cache_path = "/tmp/ruby-docker-images.#{ENV['CIRCLE_BUILD_NUM']}")
+    if File.exist?(cache_path = "/tmp/ruby-docker-images")
       return File.read(cache_path)
     end
 


### PR DESCRIPTION
We sometimes faced https://github.com/ruby/docker-images/actions/runs/10958936683/job/30430235649#step:9:68. It caused commit mismatch between build and push.

I enabled cache file for that differences.