### PR TITLE
Added LD_LIBRARY_PATH to published images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,7 @@ ARG RUBY_SO_SUFFIX
 
 ENV LANG C.UTF-8
 ENV DEBIAN_FRONTEND noninteractive
+ENV LD_LIBRARY_PATH /usr/local/lib:$LD_LIBRARY_PATH
 
 RUN set -ex && \
     apt-get update && \

--- a/install_ruby.sh
+++ b/install_ruby.sh
@@ -129,4 +129,5 @@ rm -fr /usr/src/ruby /root/.gem/
 
 # rough smoke test
 export PATH=$PREFIX/bin:$PATH
+export LD_LIBRARY_PATH=$PREFIX/lib:$LD_LIBRARY_PATH
 (cd && ruby --version && gem --version && bundle --version)


### PR DESCRIPTION
from https://github.com/ruby/docker-images/actions/runs/11097384195/job/30828525468#step:8:5499

I'm not sure why our image couldn't search .so files from `/usr/local/lib` as LD_LIBRARY_PATH. I manually added it.