### PR TITLE
Revert "Added LD_LIBRARY_PATH to published images"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,6 @@ ARG RUBY_SO_SUFFIX
 
 ENV LANG C.UTF-8
 ENV DEBIAN_FRONTEND noninteractive
-ENV LD_LIBRARY_PATH /usr/local/lib:$LD_LIBRARY_PATH
 
 RUN set -ex && \
     apt-get update && \

--- a/install_ruby.sh
+++ b/install_ruby.sh
@@ -129,5 +129,4 @@ rm -fr /usr/src/ruby /root/.gem/
 
 # rough smoke test
 export PATH=$PREFIX/bin:$PATH
-export LD_LIBRARY_PATH=$PREFIX/lib:$LD_LIBRARY_PATH
 (cd && ruby --version && gem --version && bundle --version)


### PR DESCRIPTION
https://github.com/ruby/ruby/commit/79a8750ade3e332c1ab78aa9cbc6ca7fd823dec2 is fixed root cause of this.