### PR TITLE
Don't use releases.yml when release time.

### DIFF
--- a/install_ruby.sh
+++ b/install_ruby.sh
@@ -11,13 +11,18 @@ function get_released_ruby() {
   cat << RUBY | ruby - $1
 require "net/http"
 require "uri"
+require "open-uri"
+require "digest"
 ver2 = ARGV[0].split('.')[0,2].join('.')
 if Net::HTTP.get_response(URI.parse("https://cache.ruby-lang.org/pub/ruby/#{ver2}/ruby-#{ARGV[0]}.tar.gz")).code == "200"
   url = "https://cache.ruby-lang.org/pub/ruby/#{ver2}/ruby-#{ARGV[0]}.tar.gz"
-  sha256 = `curl -sSL #{url} | sha256sum`.split(' ')[0]
-  puts "#{url} #{sha256}"
+  URI.open(url) do |f|
+    sha256 = Digest::SHA256.hexdigest(f.read)
+    puts "#{url} #{sha256}"
+  end
 else
   exit 1
+end
 RUBY
 }
 

--- a/install_ruby.sh
+++ b/install_ruby.sh
@@ -14,8 +14,8 @@ require "uri"
 require "open-uri"
 require "digest"
 ver2 = ARGV[0].split('.')[0,2].join('.')
-if Net::HTTP.get_response(URI.parse("https://cache.ruby-lang.org/pub/ruby/#{ver2}/ruby-#{ARGV[0]}.tar.gz")).code == "200"
-  url = "https://cache.ruby-lang.org/pub/ruby/#{ver2}/ruby-#{ARGV[0]}.tar.gz"
+if Net::HTTP.get_response(URI.parse("https://cache.ruby-lang.org/pub/ruby/#{ver2}/ruby-#{ARGV[0]}.tar.xz")).code == "200"
+  url = "https://cache.ruby-lang.org/pub/ruby/#{ver2}/ruby-#{ARGV[0]}.tar.xz"
   URI.open(url) do |f|
     sha256 = Digest::SHA256.hexdigest(f.read)
     puts "#{url} #{sha256}"


### PR DESCRIPTION
Fix https://github.com/ruby/docker-images/actions/runs/11591149300/job/32270268536#step:5:3268

We can't look releases.yml at that time. we should refer tar file directly.