### PR TITLE
Check exit status of curl

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -134,7 +134,10 @@ namespace :docker do
       return File.read(cache_path)
     end
 
-    head_hash = `curl -H 'accept: application/vnd.github.v3.sha' https://api.github.com/repos/ruby/ruby/commits/master`.chomp
+    head_hash = `curl -fs -H 'accept: application/vnd.github.v3.sha' https://api.github.com/repos/ruby/ruby/commits/master`.chomp
+    unless $?.success?
+      raise "get_ruby_master_head_hash failed: #{head_hash.inspect}"
+    end
     if cache_path
       File.write(cache_path, head_hash)
     end


### PR DESCRIPTION
I think here is root cause of following exception:

```
ArgumentError: Invalid commit_hash: "{\"message\""
/home/runner/work/docker-images/docker-images/Rakefile:145:in `get_ruby_version_at_commit'
/home/runner/work/docker-images/docker-images/Rakefile:202:in `block (2 levels) in <top (required)>'
```
