### PR TITLE
Use more regex

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -152,10 +152,7 @@ COPY --from=build \
      /usr/local/lib/ruby/
 
 COPY --from=build \
-     /usr/local/share/man/man1/erb* \
-     /usr/local/share/man/man1/irb* \
-     /usr/local/share/man/man1/ri* \
-     /usr/local/share/man/man1/ruby* \
+     /usr/local/share/man/man1/*.* \
      /usr/local/share/man/man1/
 
 


### PR DESCRIPTION
We will remove irb and ri manpages at Ruby 3.5. Dockerfile should support it.