### PR TITLE
Don't need docker/login-action now

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,12 +27,6 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
-        with:
-          registry: ghcr.io
-          username: ${{ secrets.GHCR_USER }}
-          password: ${{ secrets.GHCR_ACCESS_TOKEN }}
-
       - name: Build image
         run: |
           rake docker:build arch=${{ matrix.arch }} ruby_version=${{ matrix.ruby_version }} ubuntu_version=${{ matrix.ubuntu_version }}


### PR DESCRIPTION
We can pull base images from ghcr.io now.