### PR TITLE
Enable ZJIT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,6 @@ RUN set -ex && \
             libyaml-dev \
             make \
             ruby \
-            rustc \
             tzdata \
             wget \
             xz-utils \
@@ -38,6 +37,9 @@ RUN set -ex && \
             && \
     apt-get clean && \
     rm -r /var/lib/apt/lists/*
+RUN wget https://sh.rustup.rs -O /tmp/rustup.sh && \
+    sh /tmp/rustup.sh -y && \
+    rm -f /tmp/rustup.sh
 
 COPY tmp/ruby /usr/src/ruby
 COPY install_ruby.sh /tmp/

--- a/install_ruby.sh
+++ b/install_ruby.sh
@@ -7,6 +7,8 @@ RUBY_MAJOR=$(echo $RUBY_VERSION | sed -E 's/\.[0-9]+(-.*)?$//g')
 RUBYGEMS_VERSION=${RUBYGEMS_VERSION-3.2.3}
 PREFIX=${PREFIX-/usr/local}
 
+. "$HOME/.cargo/env"
+
 function get_released_ruby() {
   cat << RUBY | ruby - $1
 require "net/http"
@@ -93,7 +95,8 @@ fi
     --prefix="$PREFIX" \
     --disable-install-doc \
     --enable-shared \
-    --enable-yjit
+    --enable-yjit \
+    --enable-zjit
   )
 
   if [ -n "$cppflags" ]; then


### PR DESCRIPTION
This PR enables ZJIT support.

I want to use the Docker images for benchmarking ZJIT. At the moment, Ruby's `configure` enables only YJIT by default, so we need to explicitly specify `--enable-zjit` for now. Note that ZJIT requires newer Rust and building both YJIT and ZJIT requires cargo, so it changed the Rust installation method to rustup.