### PR TITLE
Push commit date tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ on:
 
 env:
   ruby_version: ${{ github.event.inputs.ruby_version || github.event.client_payload.ruby_version || 'master' }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,6 @@ jobs:
     runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
 
     env:
-      nightly: false
       push: false
       ubuntu_version: "${{ matrix.ubuntu_version }}"
       tag_suffix: "-${{ matrix.arch }}-${{ github.sha }}"
@@ -72,7 +71,6 @@ jobs:
                           ubuntu_version=${{ env.ubuntu_version }} \
                           arch=linux/${{ matrix.arch }} \
                           image_version_suffix=${{ env.debug_suffix }}${{ env.dev_suffix }} \
-                          nightly=${{ env.nightly }} \
                           tag_suffix=${{ env.tag_suffix }} \
                           optflags="${{ env.optflags }}" \
                           cppflags="${{ env.cppflags }}" \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   build:
     name: ${{ matrix.ruby_version }}-${{ matrix.ubuntu_version }} ${{ matrix.arch }}


### PR DESCRIPTION
This PR adds tags like `master-YYYYMMDD`. 

We used to have nightly tags like `master-nightly-YYYYMMDD-focal`, but https://github.com/ruby/docker-images/pull/115 removed every `nightly: true` job, so such tags are no longer pushed. The first commit of this PR removes the code that was used by `nightly: true`, which is `each_nightly_tag`. It also removes the `rake docker:push` target, which is not used either.

To make sure we push the `YYYYMMDD`-based tags, this PR adds the tag in `make_tags`. To ensure the consistency between `RUBY_RELEASE_DATE` and the date in the tag name, it fetches the commit date using GitHub API.