### PR TITLE
Link Ruby with `-z now` for full RELRO

### DIFF
--- a/install_ruby.sh
+++ b/install_ruby.sh
@@ -117,6 +117,10 @@ fi
     unset debugflags
   fi
 
+  # Full RELRO: -z now disables lazy binding so the loader can map the GOT
+  # read-only at startup, removing it as a target for arbitrary-write exploits.
+  export LDFLAGS="-Wl,-z,relro,-z,now${LDFLAGS:+ $LDFLAGS}"
+
   /usr/src/ruby/configure "${configure_args[@]}" || {
     cat config.log | grep flags=
     exit 1


### PR DESCRIPTION
### Motivation / Background

`install_ruby.sh` calls `configure` without setting `LDFLAGS`, so the base image's linker
defaults decide the RELRO posture of the build. On Ubuntu those defaults cover executables but
not shared objects:

```
$ gcc -o exe h.c ; gcc -shared -fPIC -o lib.so h.c    # ubuntu:24.04, gcc 13.3.0
exe      GNU_RELRO=yes  BIND_NOW=yes
lib.so   GNU_RELRO=yes  BIND_NOW=no
```

The images are built `--enable-shared`, so `/usr/local/bin/ruby` is a small stub and the
interpreter itself lives in `libruby.so`. The object the default misses is the one that holds
essentially all of the code.

Without `-z now` the loader cannot map the GOT read-only, so it stays writable for the life of
the process. That leaves a table of function pointers, which the process dereferences on
every external call, writable by anyone who already has an arbitrary write. Making it read-only
does not fix a memory safety bug in a linked C library, but it removes one of the easier ways to
escalate a memory write into code execution.

Ubuntu and Debian already link their own `libruby` this way. Both `libruby-3.2.so.3.2` on
`ubuntu:24.04` and `libruby-3.3.so.3.3` on `debian:trixie` report `FLAGS: BIND_NOW`. This change
brings `rubylang/ruby` in line with the distribution packages it sits next to.

### Detail

Export `LDFLAGS` before `configure`. Ruby's `configure` appends its own flags rather than
replacing what it inherits, and `: ${DLDFLAGS="$LDFLAGS"}` in
[`configure.ac`](https://github.com/ruby/ruby/blob/master/configure.ac) seeds `DLDFLAGS` from the
same value, so one export reaches the interpreter, `libruby.so`, and any native extension built
later in a derived image.

Building `ruby-4.0.6` on `ubuntu:24.04` twice with `--build`, `--disable-install-doc`, and
`--enable-shared`, before and after:

| | `bin/ruby` | `libruby.so.4.0.6` |
|---|---|---|
| before | `GNU_RELRO`, `BIND_NOW` | `GNU_RELRO`, no `BIND_NOW` |
| after | `GNU_RELRO`, `BIND_NOW` | `GNU_RELRO`, `BIND_NOW` |

The resulting `RbConfig` values, which is what native gems inherit:

```
before  LDFLAGS   -L. -fstack-protector-strong -rdynamic -Wl,-export-dynamic -Wl,--no-as-needed
        DLDFLAGS  -Wl,--compress-debug-sections=zlib

after   LDFLAGS   -L. -Wl,-z,relro,-z,now -fstack-protector-strong -rdynamic -Wl,-export-dynamic -Wl,--no-as-needed
        DLDFLAGS  -Wl,-z,relro,-z,now -Wl,--compress-debug-sections=zlib
```

`-z relro` is redundant on both Ubuntu and Debian, where it is already the default. It is spelled
out so the pair reads as one intent and so the build does not silently drop to partial RELRO on a
base image whose defaults differ.

The cost is that symbol resolution happens eagerly at startup rather than on first call. Measured
with `hyperfine`, shell disabled, 30 warmup and 300 timed runs, pinned to one CPU, six repetitions
with alternating order, 1800 samples per image:

| workload | control | `-z now` | paired difference |
|---|---|---|---|
| `ruby --disable-gems` empty script | 4.99ms | 5.03ms | +0.07ms (+1.5%) |
| `ruby` empty script | 34.36ms | 34.45ms | -0.14ms (-0.4%) |
| `ruby` + 6 C extensions | 56.84ms | 57.38ms | +0.55ms (+1.0%) |
| full Rails boot (1.33s) | 1326ms | 1331ms | not detectable |

Medians. The extension-heavy case is the one that isolates the mechanism, and its penalty is about
one percent, at the edge of what these runs separate from noise: the paired difference is +0.55ms
with a standard deviation of 0.71ms, though the sign held in 5 of 6 repetitions. At Rails boot
scale it disappears into run-to-run drift. `libruby.so` carries 1415 PLT relocations, so
sub-millisecond is the expected size.

The `${LDFLAGS:+ $LDFLAGS}` suffix keeps any externally supplied `LDFLAGS` and lets it win, so a
caller who needs the old behaviour can still get it.

Built a real application against the patched image: [Fizzy](https://github.com/basecamp/fizzy), a
Rails 8 app, using its own production `Dockerfile` unmodified apart from the base image.
`bundle install` compiled 62 native extensions under `BUNDLE_DEPLOYMENT=1` with no failures. Puma
and SolidQueue boot, `GET /up` returns 200, and a `rails runner` round trip through SQLite and
Nokogiri works.

Of those 62 extensions, 48 gained `BIND_NOW` and 14 did not. The 14 are precompiled platform gems
(`ffi`, `nokogiri`, and `sqlite3` in their `-x86_64-linux-gnu` builds) whose `.so` files are built
on the gem author's machine and shipped inside the gem, so no image-side `LDFLAGS` reaches them.
Everything Bundler compiles from source does inherit it.

### Additional information

This came out of looking at whether a Rails application container was exploitable given the
[libheif issues fixed in 1.23.2](https://github.com/strukturag/libheif/releases/tag/v1.23.2), one
of which ([GHSA-2jg2-4ch7-h545](https://github.com/strukturag/libheif/security/advisories/GHSA-2jg2-4ch7-h545))
has a confirmed remote code execution proof of concept. Everything else in that image held up:
the interpreter is PIE, every library is PIC, and ASLR is enforced. Partial RELRO on `libruby`
was the one gap.

`libheif` is only the example. The same reasoning applies to any C library a Ruby process links,
which for a typical application server is a long list.
